### PR TITLE
Fix: Await params in NotePage component

### DIFF
--- a/app/notes/[...slug]/page.tsx
+++ b/app/notes/[...slug]/page.tsx
@@ -5,6 +5,7 @@ export default async function NotePage({
 }: {
   params: { slug: string[] };
 }) {
-  const slugPath = params.slug.join("/");
+  const awaitedParams = await params;
+  const slugPath = awaitedParams.slug.join("/");
   return <NoteApp activeNoteId={slugPath} />;
 }


### PR DESCRIPTION
The `NotePage` component in `app/notes/[...slug]/page.tsx` was attempting to access `params.slug` synchronously. In Next.js 15+ App Router, dynamic route parameters must be awaited before their properties can be accessed in Server Components.

This commit modifies the `NotePage` component to `await params` before joining the `slug` array, resolving the "Error: Route /notes/[...slug] used params.slug. params should be awaited before using its properties" error.