### PR TITLE
Fix: Prevent redirect during new note creation

### DIFF
--- a/components/note-app.tsx
+++ b/components/note-app.tsx
@@ -131,11 +131,21 @@ export function NoteApp({ activeNoteId }: { activeNoteId?: string }) {
             router.push(`/notes/${notes[0].id}`);
           } else {
             // No notes exist at all, clear active note and go to base path
-            setActiveNote(null);
-            if (pathname !== "/notes") {
-              // Avoid redundant navigation
-              router.push("/notes");
+            // setActiveNote(null);
+            // if (pathname !== "/notes") {
+            // Avoid redundant navigation
+            // router.push("/notes");
+            // }
+            // If activeNoteId is present, but the note data isn't found yet,
+            // and the notes array seems empty to this effect's closure,
+            // it's likely a new note being created or state propagating.
+            // We should not redirect away from /notes/[activeNoteId].
+            // We can clear the activeNote if it's stale or doesn't match activeNoteId.
+            if (!activeNote || activeNote.id !== activeNoteId) {
+              setActiveNote(null);
             }
+            // CRITICALLY: The router.push("/notes") call that was here should be removed or commented out
+            // to prevent the redirect when activeNoteId is present.
           }
         }
       }
@@ -149,7 +159,7 @@ export function NoteApp({ activeNoteId }: { activeNoteId?: string }) {
         setActiveNote(null);
       }
     }
-  }, [activeNoteId, notes, openNotes, router, pathname]); // Keep dependencies
+  }, [activeNoteId, notes, openNotes, router, pathname, activeNote]); // Keep dependencies
 
   // Update open notes when notes change (e.g., title changes) - memoized to avoid unnecessary updates
   useEffect(() => {
@@ -191,6 +201,8 @@ export function NoteApp({ activeNoteId }: { activeNoteId?: string }) {
       folder: "unsaved", // Special marker for unsaved location
       tags: [],
     };
+
+    setActiveNote(newNote);
 
     setNotes((prev) => [...prev, newNote]);
     setUnsavedNoteIds((prev) => [...prev, newNote.id]);


### PR DESCRIPTION
This commit addresses an issue where creating a new note would cause a brief redirect loop or land you on `/notes` instead of the newly created note's page, especially when it was the first note.

The fix involves two main changes in `components/note-app.tsx`:

1.  In `createNewUnsavedNote`:
    - `setActiveNote(newNote)` is now called immediately after the `newNote` object is created. This ensures the application attempts to render the new note's content straight away.

2.  In the main `useEffect` responsible for syncing `activeNoteId` from the URL with the component's state:
    - The logic that handles cases where `activeNoteId` is present but the note is not yet found in the `notes` or `openNotes` state (particularly when the `notes` array appears empty to the effect's closure) has been modified.
    - Previously, if `notes` looked empty, it would redirect to `/notes`, losing the specific `activeNoteId`. This redirect has been removed for such cases. Instead, `activeNote` is cleared if it doesn't match `activeNoteId`, allowing the UI to potentially show a loading state for the specific note URL while state updates propagate.
    - `activeNote` has been added to this `useEffect`'s dependency array as it's now read within the hook.

These changes aim to make the note creation process smoother and ensure you are correctly navigated to the new note's view without unexpected redirects.